### PR TITLE
all-no-checksum

### DIFF
--- a/plugin/src/main/java/xyz/kyngs/libby/plugin/LibbyExtension.java
+++ b/plugin/src/main/java/xyz/kyngs/libby/plugin/LibbyExtension.java
@@ -12,6 +12,7 @@ import java.util.List;
 public class LibbyExtension {
     private List<String> excludedDependencies = new ArrayList<>();
     private List<String> noChecksumDependencies = new ArrayList<>();
+    private boolean doNotGenerateChecksum = false;
 
     public List<String> getExcludedDependencies() {
         return excludedDependencies;
@@ -41,5 +42,21 @@ public class LibbyExtension {
      */
     public void noChecksumDependency(String dependency) {
         noChecksumDependencies.add(dependency);
+    }
+
+    /**
+     * Returns if the checksum will not be generated.
+     */
+    public boolean isDoNotGenerateChecksum() {
+        return doNotGenerateChecksum;
+    }
+
+    /**
+     * Sets if the checksum will not be generated.
+     *
+     * @param doNotGenerateChecksum A boolean value indicates if the checksum will not be generated
+     */
+    public void setDoNotGenerateChecksum(boolean doNotGenerateChecksum) {
+        this.doNotGenerateChecksum = doNotGenerateChecksum;
     }
 }

--- a/plugin/src/main/java/xyz/kyngs/libby/plugin/LibbyTask.java
+++ b/plugin/src/main/java/xyz/kyngs/libby/plugin/LibbyTask.java
@@ -46,6 +46,7 @@ public class LibbyTask extends DefaultTask {
 
         var excludedDependencies = project.getExtensions().getByType(LibbyExtension.class).getExcludedDependencies();
         var noChecksumDependencies = project.getExtensions().getByType(LibbyExtension.class).getNoChecksumDependencies();
+        var doNotGenerateChecksum = project.getExtensions().getByType(LibbyExtension.class).isDoNotGenerateChecksum();
 
         var output = new File(project.getBuildDir().getPath() + "/libby", "libby.json");
         output.getParentFile().mkdirs();
@@ -77,12 +78,14 @@ public class LibbyTask extends DefaultTask {
             }
             var jar = artifact.getFile();
 
-            try (var fis = new java.io.FileInputStream(jar)) {
-                var bytes = fis.readAllBytes();
-                var hash = md.digest(bytes);
-                writer.value("checksum", Base64.getEncoder().encodeToString(hash));
-            } catch (IOException e) {
-                throw new RuntimeException(e);
+            if (!doNotGenerateChecksum) {
+                try (var fis = new java.io.FileInputStream(jar)) {
+                    var bytes = fis.readAllBytes();
+                    var hash = md.digest(bytes);
+                    writer.value("checksum", Base64.getEncoder().encodeToString(hash));
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
             }
 
             writer.end();


### PR DESCRIPTION
The PR allow us to prevent checksum being generated. Use at the user's risk.